### PR TITLE
Configure Grafana Release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -77,6 +77,13 @@ jobs:
             - name: Install Dependencies
               run: yarn install
 
+            - name: Set plugin version from tag
+              run: |
+                  TAG="${GITHUB_REF##*/}"
+                  VERSION="${TAG#v}"
+                  cd app/grafana
+                  npm version "$VERSION" --no-git-tag-version --allow-same-version
+
             - name: Build and package Grafana plugin
               run: |
                   cd app/grafana

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -61,6 +61,22 @@ jobs:
               run: |
                   npx lerna publish from-package --yes
 
+    grafana:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: write
+        steps:
+            - name: Checkout Repository
+              uses: actions/checkout@v4
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: "22.x"
+
+            - name: Install Dependencies
+              run: yarn install
+
             - name: Build and package Grafana plugin
               run: |
                   cd app/grafana
@@ -71,6 +87,6 @@ jobs:
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
-                  gh release upload "${{ steps.tag.outputs.tag }}" \
+                  gh release upload "${GITHUB_REF##*/}" \
                     app/grafana/jpl-honeycomb-panel.zip \
                     --clobber

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,3 +60,17 @@ jobs:
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
               run: |
                   npx lerna publish from-package --yes
+
+            - name: Build and package Grafana plugin
+              run: |
+                  cd app/grafana
+                  yarn build
+                  yarn package
+
+            - name: Upload Grafana plugin zip to release
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  gh release upload "${{ steps.tag.outputs.tag }}" \
+                    app/grafana/jpl-honeycomb-panel.zip \
+                    --clobber

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -79,10 +79,9 @@ jobs:
 
             - name: Set plugin version from tag
               run: |
-                  TAG="${GITHUB_REF##*/}"
-                  VERSION="${TAG#v}"
-                  cd app/grafana
-                  npm version "$VERSION" --no-git-tag-version --allow-same-version
+                  VERSION="${GITHUB_REF##*/}"
+                  VERSION="${VERSION#v}"
+                  npm pkg set version="$VERSION" --prefix app/grafana
 
             - name: Build and package Grafana plugin
               run: |


### PR DESCRIPTION
Updates the CI (`publish.yml`) to add a `grafana` job which builds/packages the plugin, sets the version to the release tag, and uploads the `zip` to the release.